### PR TITLE
Initial optimized nginx configs

### DIFF
--- a/conf/nginx/optimized/html
+++ b/conf/nginx/optimized/html
@@ -1,6 +1,8 @@
 worker_processes auto; # default 1
 error_log stderr error; # default to logs/error.log
 
+keepalive_requests 10000;
+
 events {
     #use epoll; by default use the best option
     worker_connections 2500; # default 512

--- a/conf/nginx/optimized/html
+++ b/conf/nginx/optimized/html
@@ -1,21 +1,19 @@
-events {
-    use epoll;
-    worker_connections 1024;
-}
+worker_processes auto; # default 1
+error_log stderr error; # default to logs/error.log
 
-worker_processes auto;
+events {
+    #use epoll; by default use the best option
+    worker_connections 2500; # default 512
+}
 
 http {
     access_log off;
     sendfile on;
-    proxy_cache_path /tmp/nginx-cache keys_zone=cache:10m;
 
     server {
         listen 0.0.0.0:8080;
-        proxy_cache cache;
 
         location / {
-            alias /srv/static/;
         }
     }
 }

--- a/conf/nginx/optimized/proxy
+++ b/conf/nginx/optimized/proxy
@@ -1,6 +1,8 @@
 worker_processes auto; # default 1
 error_log stderr error; # default to logs/error.log
 
+keepalive_requests 10000;
+
 events {
     #use epoll; by default use the best option
     worker_connections 2500; # default 512

--- a/conf/nginx/optimized/proxy
+++ b/conf/nginx/optimized/proxy
@@ -1,21 +1,21 @@
-events {
-    use epoll;
-    worker_connections 1024;
-}
+worker_processes auto; # default 1
+error_log stderr error; # default to logs/error.log
 
-worker_processes auto;
+events {
+    #use epoll; by default use the best option
+    worker_connections 2500; # default 512
+}
 
 http {
     access_log off;
-    sendfile on;
-    proxy_cache_path /tmp/nginx-cache keys_zone=cache:10m;
 
     server {
         listen 0.0.0.0:8080;
-        proxy_cache cache;
 
         location / {
             proxy_pass http://127.0.0.1:8081;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
         }
     }
 }

--- a/conf/nginx/optimized/synthetic
+++ b/conf/nginx/optimized/synthetic
@@ -1,6 +1,8 @@
 worker_processes auto; # default 1
 error_log stderr error; # default to logs/error.log
 
+keepalive_requests 10000;
+
 events {
     #use epoll; # by default use the best option
     worker_connections 2500; # default 512

--- a/conf/nginx/optimized/synthetic
+++ b/conf/nginx/optimized/synthetic
@@ -1,18 +1,16 @@
-events {
-    use epoll;
-    worker_connections 1024;
-}
+worker_processes auto; # default 1
+error_log stderr error; # default to logs/error.log
 
-worker_processes auto;
+events {
+    #use epoll; # by default use the best option
+    worker_connections 2500; # default 512
+}
 
 http {
     access_log off;
-    sendfile on;
-    proxy_cache_path /tmp/nginx-cache keys_zone=cache:10m;
 
     server {
         listen 0.0.0.0:8080;
-        proxy_cache cache;
 
         return 200 "Hello, world!";
     }


### PR DESCRIPTION
More worker connections.
By default have 512 per worker,  4 cores x 512  = 2048 max connections

Add `error_log` to `stderr`, by default to the file system.
So using http1.0, we are creating errors and also add file system IO for these errors.

Later I'll send more classic optimizations.

Tomorrow I'll add Caddy to the TechEmpower benchmark to check the numbers.